### PR TITLE
Add www. prefix to URLs

### DIFF
--- a/App/templates/email.html
+++ b/App/templates/email.html
@@ -6,7 +6,7 @@
     <div style="color: white;font-size: 30;padding-top:10px;">LibraryHippo</div>
     </div>
   </div>
-<p style="padding-top:1em;"><a href="http://libraryhippo.com/summary">Check your
+<p style="padding-top:1em;"><a href="http://www.libraryhippo.com/summary">Check your
 family's account summary</a> - this e-mail only contains items that
 are due or ready for pickup.</p>
 {% if info %}

--- a/App/templates/static_summary.html
+++ b/App/templates/static_summary.html
@@ -6,7 +6,7 @@
     <div style="color: white;font-size: 30;padding-top:10px;">LibraryHippo</div>
     </div>
   </div>
-<p style="padding-top:1em;"><a href="http://libraryhippo.com/summary">Check your
+<p style="padding-top:1em;"><a href="http://www.libraryhippo.com/summary">Check your
 family's account summary</a> - this e-mail only contains items that
 are due or ready for pickup.</p>
 {% if info %}


### PR DESCRIPTION
As per #69, I found two links in templates that are missing the www. prefix.
They used to link to http://libraryhippo.com/summary, and now they link to http://www.libraryhippo.com/summary